### PR TITLE
BUG Fix: Changing color values in IB has no effect

### DIFF
--- a/CircularSlider/Classes/CircularSlider.swift
+++ b/CircularSlider/Classes/CircularSlider.swift
@@ -136,12 +136,14 @@ open class CircularSlider: UIView {
     open var pgNormalColor: UIColor = UIColor.darkGray {
         didSet {
             appearanceProgressLayer()
+            appearanceKnobLayer()
         }
     }
     @IBInspectable
     open var pgHighlightedColor: UIColor = UIColor.green {
         didSet {
             appearanceProgressLayer()
+            appearanceKnobLayer()
         }
     }
     @IBInspectable


### PR DESCRIPTION
Changing either the colors pgNormalColor or pgHighlightedColor in IB does not have any effect in IB and the app when it is executed. 

Adding these two lines fixes that problem.